### PR TITLE
Add &QQmlApplicationEngine::loadData to julia API.

### DIFF
--- a/deps/src/qmlwrap/wrap_qml.cpp
+++ b/deps/src/qmlwrap/wrap_qml.cpp
@@ -64,6 +64,19 @@ JULIA_CPP_MODULE_BEGIN(registry)
         e->quit();
         jl_error("Error loading QML");
       }
+    })
+    .method("load_data", [] (QQmlApplicationEngine* e, const QByteArray &data)
+    {
+      bool success = false;
+      QUrl url = QUrl();
+      auto conn = QObject::connect(e, &QQmlApplicationEngine::objectCreated, [&] (QObject* obj, const QUrl& url) { success = (obj != nullptr); });
+      e->loadData(data, url);
+      QObject::disconnect(conn);
+      if(!success)
+      {
+        e->quit();
+        jl_error("Error loading QML");
+      }
     });
 
   qml_module.method("qt_prefix_path", []() { return QLibraryInfo::location(QLibraryInfo::PrefixPath); });
@@ -180,6 +193,6 @@ JULIA_CPP_MODULE_BEGIN(registry)
   qml_module.method("getindex", [](const QVariantMap& m, const QString& key) { return m[key]; });
 
   // Exports:
-  qml_module.export_symbols("QQmlContext", "set_context_property", "root_context", "load", "qt_prefix_path", "set_source", "engine", "QByteArray", "to_string", "QQmlComponent", "set_data", "create", "QQuickItem", "content_item", "JuliaObject", "QTimer", "context_property", "emit", "JuliaDisplay", "init_application", "qmlcontext", "init_qmlapplicationengine", "init_qmlengine", "init_qquickview", "exec", "exec_async", "ListModel", "addrole", "setconstructor", "removerole", "setrole", "QVariantMap");
+  qml_module.export_symbols("QQmlContext", "set_context_property", "root_context", "load", "load_data", "qt_prefix_path", "set_source", "engine", "QByteArray", "to_string", "QQmlComponent", "set_data", "create", "QQuickItem", "content_item", "JuliaObject", "QTimer", "context_property", "emit", "JuliaDisplay", "init_application", "qmlcontext", "init_qmlapplicationengine", "init_qmlengine", "init_qquickview", "exec", "exec_async", "ListModel", "addrole", "setconstructor", "removerole", "setrole", "QVariantMap");
   qml_module.export_symbols("QPainter", "device", "width", "height", "logicalDpiX", "logicalDpiY", "QQuickWindow", "effectiveDevicePixelRatio", "window", "JuliaPaintedItem", "update");
 JULIA_CPP_MODULE_END

--- a/src/QML.jl
+++ b/src/QML.jl
@@ -212,6 +212,11 @@ You can now use `my_property` in QML and every time `set_context_property` is ca
 Equivalent to [`&QQmlApplicationEngine::load`](http://doc.qt.io/qt-5/qqmlapplicationengine.html#load-1). The first argument is
 the application engine, the second is a string containing a path to the local QML file to load.
 """ load
+@doc """
+Equivalent to [`&QQmlApplicationEngine::loadData`](http://doc.qt.io/qt-5/qqmlapplicationengine.html#loadData). Use this to
+load QML from a string. The first argument is the application engine, the second is either a `QML.QByteArray` or a `String`
+containing QML to load.
+""" load_data
 
 @doc "Equivalent to `QLibraryInfo::location(QLibraryInfo::PrefixPath)`" qt_prefix_path
 @doc "Equivalent to `QQuickWindow::contentItem`" content_item


### PR DESCRIPTION
In addition to the existing `load`, wrap QQmlApplicationEngine::loadData
(https://doc-snapshots.qt.io/qt5-5.9/qqmlapplicationengine.html#loadData)
in the generated julia API, which loads QML from a string instead of
a file, in order to allow julia to generat the QML at runtime.

This allows templatized-instantiation of QML from julia types, based on
their runtime values.