### PR TITLE
Add `&QByteArray::toString` as `to_string`

### DIFF
--- a/deps/src/qmlwrap/wrap_qml.cpp
+++ b/deps/src/qmlwrap/wrap_qml.cpp
@@ -92,7 +92,8 @@ JULIA_CPP_MODULE_BEGIN(registry)
 
   qml_module.add_type<qmlwrap::JuliaPaintedItem>("JuliaPaintedItem", julia_type<QQuickItem>());
 
-  qml_module.add_type<QByteArray>("QByteArray").constructor<const char*>();
+  qml_module.add_type<QByteArray>("QByteArray").constructor<const char*>()
+    .method("to_string", &QByteArray::toStdString);
   qml_module.add_type<QQmlComponent>("QQmlComponent", julia_type<QObject>())
     .constructor<QQmlEngine*>()
     .method("set_data", &QQmlComponent::setData);
@@ -179,6 +180,6 @@ JULIA_CPP_MODULE_BEGIN(registry)
   qml_module.method("getindex", [](const QVariantMap& m, const QString& key) { return m[key]; });
 
   // Exports:
-  qml_module.export_symbols("QQmlContext", "set_context_property", "root_context", "load", "qt_prefix_path", "set_source", "engine", "QByteArray", "QQmlComponent", "set_data", "create", "QQuickItem", "content_item", "JuliaObject", "QTimer", "context_property", "emit", "JuliaDisplay", "init_application", "qmlcontext", "init_qmlapplicationengine", "init_qmlengine", "init_qquickview", "exec", "exec_async", "ListModel", "addrole", "setconstructor", "removerole", "setrole", "QVariantMap");
+  qml_module.export_symbols("QQmlContext", "set_context_property", "root_context", "load", "qt_prefix_path", "set_source", "engine", "QByteArray", "to_string", "QQmlComponent", "set_data", "create", "QQuickItem", "content_item", "JuliaObject", "QTimer", "context_property", "emit", "JuliaDisplay", "init_application", "qmlcontext", "init_qmlapplicationengine", "init_qmlengine", "init_qquickview", "exec", "exec_async", "ListModel", "addrole", "setconstructor", "removerole", "setrole", "QVariantMap");
   qml_module.export_symbols("QPainter", "device", "width", "height", "logicalDpiX", "logicalDpiY", "QQuickWindow", "effectiveDevicePixelRatio", "window", "JuliaPaintedItem", "update");
 JULIA_CPP_MODULE_END

--- a/src/QML.jl
+++ b/src/QML.jl
@@ -139,7 +139,7 @@ function Base.display(d::JuliaDisplay, x)
   if !written
     throw(ErrorException("Can't display using any of the types $supported_types"))
   end
-  
+
 end
 
 function Base.displayable(d::JuliaDisplay, mime::AbstractString)
@@ -219,6 +219,8 @@ the application engine, the second is a string containing a path to the local QM
 @doc "Equivalent to `QQuickView::show`" show
 @doc "Equivalent to `QQuickView::engine`" engine
 @doc "Equivalent to `QQuickView::rootObject`" root_object
+
+@doc "Equivalent to `QByteArray::toString`" to_string
 
 @doc """
 Equivalent to `QQmlComponent::setData`. Use this to set the QML code for a QQmlComponent from a Julia string literal.


### PR DESCRIPTION
This is useful for viewing the contents of a QByteArray.

-----

I also considered just adding a `String` constructor or a `convert` method
override, but I thought this was the simplest. What do you think?