### PR TITLE
add ENV[GKS_QT_VERSION]=5 to fix gr.jl example

### DIFF
--- a/example/gr.jl
+++ b/example/gr.jl
@@ -17,6 +17,7 @@ A = Observable(1.0)
 function paint(p::CxxPtr{QPainter}, item::CxxPtr{JuliaPaintedItem})  
   ENV["GKS_WSTYPE"] = 381
   ENV["GKS_CONID"] = split(repr(p.cpp_object), "@")[2]
+  ENV["GKS_QT_VERSION"] = 5
 
   dev = device(p[])[]
   r = effectiveDevicePixelRatio(window(item[])[])


### PR DESCRIPTION
This is a one-line fix to example/gr.jl to avoid use of Qt4.  Qt4 is not available on CentOS8, so this pull request fixes the gr example for CentOS 8.  I can't see how it breaks the example for other systems, but I have only tested on CentOS 8.

The fix is just ENV["GKS_QT_VERSION"]=5.

Fixes issue 69 on CentOS 8, or any other system where Qt4 is not available.