### PR TITLE
Revamp docs

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,15 @@
+name: daily
+on:
+  schedule:
+    - cron: '00 00 * * *'
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: 1.3
+      - run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - run: julia -e 'using CompatHelper; CompatHelper.main()'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/permanent.yml
+++ b/.github/workflows/permanent.yml
@@ -1,0 +1,19 @@
+name: permanent
+on:
+  push:
+    branches:
+      - 'master'
+jobs:
+  document:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: '1.3'
+      - uses: julia-actions/julia-docdeploy@releases/v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: test
+on:
+  - push
+  - pull_request
+jobs:
+  test:
+    name: ${{ matrix.version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version:
+          - '1.4'
+          - 'nightly'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.version }}
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-processcoverage@v1
+        env:
+          DISABLE_AMEND_COVERAGE_FROM_SRC: yes
+      - uses: codecov/codecov-action@v1
+        with:
+          file: ./lcov.info
+          fail_ci_if_error: false
+      - uses: domluna/JuliaFormatter-action@master
+        with:
+          args: -v .
+        continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 CMakeLists.txt.user
 /Manifest.toml
 example/Manifest.toml
+/docs/build

--- a/Project.toml
+++ b/Project.toml
@@ -9,13 +9,16 @@ CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 Fontconfig_jll = "a3f928ae-7b40-5064-980b-68af3947d34b"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Observables = "510215fc-4207-5dde-b226-833fc4488ee2"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 jlqml_jll = "6b5019fb-a83d-5b4e-a9f7-678a36c28df7"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "BenchmarkTools"]
+test = ["Documenter", "Plots", "Test", "BenchmarkTools"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # QML
 
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://barche.github.io/QML.jl/dev)
 [![Build Status](https://travis-ci.org/barche/QML.jl.svg?branch=master)](https://travis-ci.org/barche/QML.jl)
 [![Build status](https://ci.appveyor.com/api/projects/status/7edud4w38g8m17yw?svg=true)](https://ci.appveyor.com/project/barche/qml-jl)
 
@@ -28,14 +29,18 @@ override USE_SYSTEM_LLVM=1
 ```
 
 ## Usage
+
 ### Running examples
 To run the included examples, execute:
+
 ```julia
 include(joinpath(Pkg.dir("QML"), "example", "runexamples.jl"))
 ```
+
 The examples require some additional packages to be described by the manifest and project files in the examples directory, so from the examples directory you should
 start Julia with `julia --project` and then run `instantiate` from the pkg shell.
 
+<<<<<<< HEAD
 ### Loading a QML file
 We support three methods of loading a QML file: `QQmlApplicationEngine`, `QQuickView` and `QQmlComponent`. These behave equivalently to the corresponding Qt classes.
 #### QQmlApplicationEngine
@@ -425,6 +430,9 @@ include("example/repl-background.jl")
 plot([1,2],[3,4])
 ```
 This should display the result of the plotting command in the QML window.
+=======
+For further examples, see the [`documentation`](https://barche.github.io/QML.jl/dev).
+>>>>>>> bramtayl_fix_warnings
 
 ## Breaking changes
 * Signals in `JuliaSignals` must have arguments of type `var`

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # QML
 
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://barche.github.io/QML.jl/dev)
-[![Build Status](https://travis-ci.org/barche/QML.jl.svg?branch=master)](https://travis-ci.org/barche/QML.jl)
-[![Build status](https://ci.appveyor.com/api/projects/status/7edud4w38g8m17yw?svg=true)](https://ci.appveyor.com/project/barche/qml-jl)
+[![Latest](https://img.shields.io/badge/docs-dev-blue.svg)](https://barche.github.io/QML.jl/dev)
+[![CodeCov](https://codecov.io/gh/barche/QML.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/barche/QML.jl)
 
 This package provides an interface to [Qt5 QML](http://qt.io/). It uses the [`CxxWrap`](https://github.com/barche/CxxWrap.jl) package to expose C++ classes. Current functionality allows interaction between QML and Julia using basic numerical and string types, as well as display of PNG images and a very experimental OpenGL rendering element (see `example/gltriangle.jl`).
 
@@ -40,7 +39,6 @@ include(joinpath(Pkg.dir("QML"), "example", "runexamples.jl"))
 The examples require some additional packages to be described by the manifest and project files in the examples directory, so from the examples directory you should
 start Julia with `julia --project` and then run `instantiate` from the pkg shell.
 
-<<<<<<< HEAD
 ### Loading a QML file
 We support three methods of loading a QML file: `QQmlApplicationEngine`, `QQuickView` and `QQmlComponent`. These behave equivalently to the corresponding Qt classes.
 #### QQmlApplicationEngine
@@ -373,6 +371,7 @@ QML.jl provides a custom QML type named `JuliaDisplay` that acts as a standard J
  Of course the display can also be added using `pushdisplay!`, but passing by value can be more convenient when defining multiple displays in QML.
 
 ## JuliaCanvas
+
 QML.jl provides a custom QML type named `JuliaCanvas` which presents a canvas to be painted via a julia callback function.  This approach avoids the MIME content encoding overhead of the JuliaDisplay approach.
 
 Example use in QML from the `canvas` example:
@@ -388,7 +387,7 @@ Example use in QML from the `canvas` example:
  ```
  The callback function `paint_cfunction` is defined in julia:
  ```julia
- 
+
  # fix callback arguments (TODO: macro this?)
  function paint_circle(buffer::Array{UInt32, 1},
                        width32::Int32,
@@ -410,11 +409,11 @@ function paint_circle(buffer)
         end
     end
  end
- 
+
  load(qmlfile,
       #...
       paint_cfunction = CxxWrap.@safe_cfunction(paint_circle, Cvoid, (Array{UInt32,1}, Int32, Int32))
- ) 
+ )
 ```
 Note that the canvas buffer is allocated (and freed) in the C++ code.  A new unitialized buffer is allocated for each frame (this could change).
 
@@ -430,9 +429,8 @@ include("example/repl-background.jl")
 plot([1,2],[3,4])
 ```
 This should display the result of the plotting command in the QML window.
-=======
+
 For further examples, see the [`documentation`](https://barche.github.io/QML.jl/dev).
->>>>>>> bramtayl_fix_warnings
 
 ## Breaking changes
 * Signals in `JuliaSignals` must have arguments of type `var`

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,5 @@
+using QML
+using Documenter: deploydocs, makedocs
+
+makedocs(sitename = "QML.jl", modules = [QML], doctest = false)
+deploydocs(repo = "github.com/barche/QML.jl.git")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,37 @@
+# QML
+
+## Loading
+
+We support three methods of loading a QML file: [`QML.QQmlApplicationEngine`](@ref),
+[`QML.QQuickView`](@ref) and [`QQmlComponent`](@ref). These behave equivalently to the
+corresponding Qt classes. They have different advantages:
+
+- You can simply [`load`](@ref) a QML file as a [`QML.QQmlApplicationEngine`](@ref).
+- [`QML.QQuickView`](@ref) creates a window, so it's not necessary to wrap the QML in `ApplicationWindow`.
+- You can run QML code contained in a string with [`QQmlComponent`](@ref).
+
+## Interaction
+
+Interaction with Julia happens through the following mechanisms:
+
+* Call Julia functions from QML, e.g. with [`@qmlfunction`](@ref).
+* Read and set context properties from Julia and QML, e.g. with keywords to [`load`](@ref) or [`set_context_property`](@ref).
+* Emit signals from Julia to QML, e.g. with [`@emit`](@ref).
+* Use data models, e.g. [`ListModel`](@ref) or [`JuliaPropertyMap`](@ref).
+
+Note that Julia slots appear missing, but they are not needed since it is possible to directly connect a Julia function to a QML signal in the QML code, e.g. with [`QTimer`](@ref).
+
+## Type conversion
+Most fundamental types are converted implicitly. Mind that the default integer type in QML corresponds to `Int32` in Julia.
+
+We also convert `QVariantMap`, exposing the indexing operator `[]` to access element by a string key. This mostly to deal with arguments passed to the QML `append` function in list models.
+
+## Interface
+
+```@index
+Modules = [QML]
+```
+
+```@autodocs
+Modules = [QML]
+```

--- a/src/QML.jl
+++ b/src/QML.jl
@@ -554,11 +554,11 @@ Base.push!(m::ListModelData, val) = push!(m.values, val)
 
 Constructor for a ListModel. The `ListModel` type allows using data in QML views such as
 `ListView` and `Repeater`, providing a two-way synchronization of the data. A ListModel is
-constructed from a 1D Julia array. To use the model from QML, it can
-be exposed as a context attribute.
+constructed from a 1D Julia array. To use the model from QML, it can be exposed as a context
+attribute.
 
-If the `eltype` has fieldnames, a constructor based on these fields and setter and getter
-"roles" will be automatically created if `addroles` is `true`.
+A constructor (the `eltype`) and setter and getter "roles" based on the `fieldnames` of the
+`eltype` will be automatically created if `addroles` is `true`.
 
 If new elements need to be constructed from QML, a constructor can also be provided, using
 the [`setconstructor`](@ref) method.
@@ -650,7 +650,7 @@ roles(lm::ListModel) = rolenames(get_julia_data(lm))
 Add your own `getter` (and optionally, `setter`) functions to a [`ListModel`](@ref) for use
 by QML. `setter` is optional, and if it is not provided the role will be read-only. `getter`
 will process an item before it is returned. The arguments of `setter` will be
-`collection, new_value, key` as in the standard `setindex!` function. If you would like to
+`collection, new_value, index` as in the standard `setindex!` function. If you would like to
 see the roles defined for a list, use [`roles`](@ref). To remove a role, use
 [`removerole`](@ref).
 
@@ -777,8 +777,8 @@ end
 """
     function setconstructor(model::ListModel, constructor)
 
-Add a constructor to a list model. The `constructor` will process `append`ed items before
-they are added.
+Add a constructor to a [`ListModel`](@ref). The `constructor` will process `append`ed items
+before they are added.
 
 ```jldoctest
 julia> using QML

--- a/src/QML.jl
+++ b/src/QML.jl
@@ -779,7 +779,7 @@ end
     function setconstructor(model::ListModel, constructor)
 
 Add a constructor to a [`ListModel`](@ref). The `constructor` will process `append`ed items
-before they are added. Note that you can simply pass a list of arguments tofrom QML,
+before they are added. Note that you can simply pass a list of arguments from QML,
 and they will be interpret in Julia as positional arguments.
 
 ```jldoctest

--- a/src/QML.jl
+++ b/src/QML.jl
@@ -1,10 +1,10 @@
 module QML
 
 export QVariant, QString, QUrl
-export QQmlContext, root_context, load, qt_prefix_path, set_source, engine, QByteArray, to_string, QQmlComponent, set_data, create, QQuickItem, content_item, QTimer, context_property, emit, JuliaDisplay, JuliaCanvas, qmlcontext, init_qmlengine, init_qquickview, exec, exec_async, ListModel, addrole, setconstructor, removerole, setrole, roles, QVariantMap
+export QQmlContext, root_context, load, qt_prefix_path, set_source, engine, QByteArray, to_string, QQmlComponent, set_data, create, QQuickItem, content_item, JuliaObject, QTimer, context_property, emit, JuliaDisplay, JuliaCanvas, init_application, qmlcontext, init_qmlapplicationengine, init_qmlengine, init_qquickview, exec, exec_async, ListModel, addrole, setconstructor, removerole, setrole, roles, QVariantMap
 export JuliaPropertyMap
 export QStringList, QVariantList
-export QPainter, device, width, height, logicalDpiX, logicalDpiY, QQuickWindow, effectiveDevicePixelRatio, window, JuliaPaintedItem
+export QPainter, device, width, height, logicalDpiX, logicalDpiY, QQuickWindow, effectiveDevicePixelRatio, window, JuliaPaintedItem, update
 export @emit, @qmlfunction, qmlfunction, load, QQmlPropertyMap
 export set_context_property
 

--- a/src/QML.jl
+++ b/src/QML.jl
@@ -1,12 +1,14 @@
 module QML
 
 export QVariant, QString, QUrl
-export QQmlContext, root_context, load, qt_prefix_path, set_source, engine, QByteArray, to_string, QQmlComponent, set_data, create, QQuickItem, content_item, JuliaObject, QTimer, context_property, emit, JuliaDisplay, JuliaCanvas, init_application, qmlcontext, init_qmlapplicationengine, init_qmlengine, init_qquickview, exec, exec_async, ListModel, addrole, setconstructor, removerole, setrole, roles, QVariantMap
+export QQmlContext, root_context, load, qt_prefix_path, set_source, engine, QByteArray, to_string, QQmlComponent, set_data, create, QQuickItem, content_item, QTimer, context_property, emit, JuliaDisplay, qmlcontext, init_qmlengine, init_qquickview, exec, exec_async, ListModel, addrole, setconstructor, removerole, setrole, roles, QVariantMap
 export JuliaPropertyMap
 export QStringList, QVariantList
-export QPainter, device, width, height, logicalDpiX, logicalDpiY, QQuickWindow, effectiveDevicePixelRatio, window, JuliaPaintedItem, update
+export QPainter, device, width, height, logicalDpiX, logicalDpiY, QQuickWindow, effectiveDevicePixelRatio, window, JuliaPaintedItem
 export @emit, @qmlfunction, qmlfunction, load, QQmlPropertyMap
 export set_context_property
+
+# TODO: Document GR: device, width, height, JuliaPaintedItem, window, effectiveDevicePixelRatio, logicalDpiX, logicalDpiY
 
 using jlqml_jll
 
@@ -21,6 +23,7 @@ import Libdl
 using Requires
 using Fontconfig_jll: fonts_conf
 using ColorTypes
+using MacroTools: @capture
 
 const envfile = joinpath(dirname(dirname(@__FILE__)), "deps", "env.jl")
 if isfile(envfile)
@@ -47,14 +50,11 @@ function load_qml(qmlfilename, engine)
 end
 
 """
+    function load(qml_file::String; properties...)
 
-load(qml_file, prop1=x, prop2=y, ...)
-
-Load a QML file, creating a QQmlApplicationEngine and setting the context properties supplied in the keyword arguments. Returns the created engine.
-
-load(qml_file, context_object)
-
-Load a QML file, creating a QQmlApplicationEngine and setting the context object to the supplied QObject
+Load a QML file, creating a [`QML.QQmlApplicationEngine`](@ref), and setting the context
+`properties` supplied in the keyword arguments. Will create and return a
+`QQmlApplicationEngine`. See the example for [`QML.QQmlApplicationEngine`](@ref).
 """
 function FileIO.load(f::FileIO.File{format"QML"}; kwargs...)
   qml_engine = init_qmlapplicationengine()
@@ -177,10 +177,6 @@ Base.setindex!(propmap::QQmlPropertyMap, val::Irrational, key::AbstractString) =
 
 function on_value_changed end
 
-"""
-Store Julia values for access from QML. Observables are connected so they change on the QML side when updated from Julia
-and vice versa.
-"""
 mutable struct JuliaPropertyMap <: AbstractDict{String,Any}
   propertymap::_JuliaPropertyMap
   dict::Dict{String, Any}
@@ -198,6 +194,46 @@ mutable struct JuliaPropertyMap <: AbstractDict{String,Any}
   end
 end
 
+"""
+    function JuliaPropertyMap(pairs...)
+
+Store Julia values for access from QML. `Observables` are connected so they change on the
+QML side when updated from Julia and vice versa only when passed in a property map. Note
+that in the example below, if you run `output[] = new_value` from within Julia, the slider
+in QML will move.
+
+```jldoctest
+julia> using QML
+
+julia> using Observables: Observable, on
+
+julia> output = Observable(0.0);
+
+julia> on(println, output);
+
+julia> mktempdir() do folder
+         path = joinpath(folder, "main.qml")
+         write(path, \"""
+         import QtQuick 2.0
+         import QtQuick.Controls 1.0
+         ApplicationWindow {
+           visible: true
+           Slider {
+             onValueChanged: {
+               observables.output = value;
+             }
+           }
+           Timer {
+             running: true
+             onTriggered: Qt.quit()
+           }
+         }
+         \""")
+         load(path; observables = JuliaPropertyMap("output" => output))
+         exec()
+       end
+```
+"""
 function JuliaPropertyMap(pairs::Pair{<:AbstractString,<:Any}...)
   result = JuliaPropertyMap()
   for (k,v) in pairs
@@ -267,18 +303,27 @@ end
   end
 end
 
+expand_dots(source_expr, func) =
+  if @capture source_expr object_.field_
+    Expr(:call, func, expand_dots(object, func), String(field))
+  else
+    source_expr
+  end
+
 """
-Expand an expression of the form a.b.c to replace the dot operator by function calls:
-`@expand_dots a.b.c.d f` returns `f(f(f(a,"b"),"c"),"d")`
+    QML.@expand_dots object_.field_ func
+
+Expand an expression of the form a.b.c to replace the dot operator by function calls.
+
+```jldoctest
+julia> using QML
+
+julia> @macroexpand QML.@expand_dots a.b.c.d f
+:(f(f(f(a, "b"), "c"), "d"))
+```
 """
 macro expand_dots(source_expr, func)
-  if source_expr.head == :escape
-    source_expr = source_expr.args[1]
-  end
-  if isa(source_expr, Expr) && source_expr.head == :(.)
-    return :($func(@expand_dots($(esc(source_expr.args[1])), $func), $(string(source_expr.args[2].args[1]))))
-  end
-  return esc(source_expr)
+  esc(expand_dots(source_expr, func))
 end
 
 function emit(name, args...)
@@ -290,9 +335,52 @@ function emit(name, args...)
 end
 
 """
-Emit a signal in the form:
-```
-@emit signal_name(arg1, arg2)
+    @emit signal_name(arguments...)
+
+Emit a signal from Julia to QML. Handle signals in QML using a `JuliaSignals` block. See the
+example below for syntax.
+
+!!! warning
+    There must never be more than one JuliaSignals block in QML
+
+```jldoctest
+julia> using QML
+
+julia> duplicate(value) = @emit duplicateSignal(value);
+
+julia> @qmlfunction duplicate
+
+julia> mktempdir() do folder
+          path = joinpath(folder, "main.qml")
+          write(path, \"""
+          import QtQuick 2.2
+          import QtQuick.Controls 1.1
+          import QtQuick.Layouts 1.1
+          import org.julialang 1.0
+          ApplicationWindow {
+              visible: true
+              Column {
+                TextField {
+                    id: input
+                    onTextChanged: Julia.duplicate(text)
+                }
+                Text {
+                    id: output
+                }
+                JuliaSignals {
+                  signal duplicateSignal(var value)
+                  onDuplicateSignal: output.text = value
+                }
+                Timer {
+                  running: true
+                  onTriggered: Qt.quit()
+                }
+              }
+          }
+          \""")
+          load(path)
+          exec()
+        end
 ```
 """
 macro emit(expr)
@@ -300,9 +388,42 @@ macro emit(expr)
 end
 
 """
-Register a Julia function for access from QML:
-```
-@qmlfunction MyFunc
+    @qmlfunction function_names...
+
+Register Julia functions for access from QML under their own name. Function names must be
+valid in QML, e.g. they can't contain `!`. You can use your newly registered functions in
+QML by first importing `org.julialang 1.0`, and then calling them with
+`Julia.function_name(arguments...)`. If you would like to register a function under a
+different name, use [`qmlfunction`](@ref). This will be necessary for non-exported functions
+from a different module or in case the function contains a `!` character.
+
+```jldoctest
+julia> using QML
+
+julia> greet() = "Hello, World!";
+
+julia> @qmlfunction greet
+
+julia> mktempdir() do folder
+          path = joinpath(folder, "main.qml")
+          write(path, \"""
+          import org.julialang 1.0
+          import QtQuick 2.0
+          import QtQuick.Controls 1.0
+          ApplicationWindow {
+            visible: true
+            Text {
+              text: Julia.greet()
+            }
+            Timer {
+              running: true
+              onTriggered: Qt.quit()
+            }
+          }
+          \""")
+          load(path)
+          exec()
+        end
 ```
 """
 macro qmlfunction(fnames...)
@@ -429,7 +550,69 @@ clear(m::ListModelData) = empty!(m.values)
 Base.push!(m::ListModelData, val) = push!(m.values, val)
 
 """
-Constructor for ListModel that automatically creates a constructor and setter and getter functions for each field if addroles == true
+    function ListModel(items::AbstractVector, addroles::Bool = true)
+
+Constructor for a ListModel. The `ListModel` type allows using data in QML views such as
+`ListView` and `Repeater`, providing a two-way synchronization of the data. A ListModel is
+constructed from a 1D Julia array. To use the model from QML, it can
+be exposed as a context attribute.
+
+If the `eltype` has fieldnames, a constructor based on these fields and setter and getter
+"roles" will be automatically created if `addroles` is `true`.
+
+If new elements need to be constructed from QML, a constructor can also be provided, using
+the [`setconstructor`](@ref) method.
+
+In Qt, each of the elements of a model has a series of roles, available as properties in the
+delegate that is used to display each item. The roles can be added using the
+[`addrole`](@ref) function.
+
+```jldoctest
+julia> using QML
+
+julia> mutable struct Fruit
+          name::String
+          cost::Float64
+        end
+
+julia> fruits = ListModel([Fruit("apple", 1.0), Fruit("orange", 2.0)]);
+
+julia> mktempdir() do folder
+          path = joinpath(folder, "main.qml")
+          write(path, \"""
+          import QtQuick 2.0
+          import QtQuick.Controls 1.0
+          import QtQuick.Layouts 1.0
+          ApplicationWindow {
+            visible: true
+            ListView {
+              model: fruits
+              anchors.fill: parent
+              delegate:
+                Row {
+                  Text {
+                    text: name
+                  }
+                  Button {
+                    text: "Sale"
+                    onClicked: cost = cost / 2
+                  }
+                  Button {
+                    text: "Duplicate"
+                    onClicked: fruits.append({"name": name, "cost": cost})
+                  }
+                  Timer {
+                    running: true
+                    onTriggered: Qt.quit()
+                  }
+                }
+            }
+          }
+          \""")
+          load(path; fruits = fruits)
+          exec()
+        end
+```
 """
 function ListModel(a::AbstractVector{T}, addroles=true) where {T}
   data = ListModelData(a)
@@ -454,8 +637,65 @@ function ListModel(a::AbstractVector{T}, addroles=true) where {T}
   return ListModel(data)
 end
 
+"""
+    function roles(model::ListModel)
+
+See all roles defined for a [`ListModel`](@ref). See the example for [`addrole`](@ref).
+"""
 roles(lm::ListModel) = rolenames(get_julia_data(lm))
 
+"""
+    function addrole(model::ListModel, name::String, getter, [setter])
+
+Add your own `getter` (and optionally, `setter`) functions to a [`ListModel`](@ref) for use
+by QML. `setter` is optional, and if it is not provided the role will be read-only. `getter`
+will process an item before it is returned. The arguments of `setter` will be
+`collection, new_value, key` as in the standard `setindex!` function. If you would like to
+see the roles defined for a list, use [`roles`](@ref). To remove a role, use
+[`removerole`](@ref).
+
+```jldoctest
+julia> using QML
+
+julia> items = ["A", "B"];
+
+julia> array_model = ListModel(items, false);
+
+julia> addrole(array_model, "item", identity, setindex!)
+
+julia> roles(array_model)
+1-element QML.QStringListAllocated:
+ "item"
+
+julia> mktempdir() do folder
+          path = joinpath(folder, "main.qml")
+          write(path, \"""
+          import QtQuick 2.0
+          import QtQuick.Controls 1.0
+          import QtQuick.Layouts 1.0
+          ApplicationWindow {
+            visible: true
+            ListView {
+              model: array_model
+              anchors.fill: parent
+              delegate: TextField {
+                placeholderText: item
+                onTextChanged: item = text;
+              }
+            }
+            Timer {
+              running: true
+              onTriggered: Qt.quit()
+            }
+          }
+          \""")
+          load(path; array_model = array_model)
+          exec()
+        end
+
+julia> removerole(array_model, "item")
+```
+"""
 function addrole(lm::ListModel, name, getter, setter=defaultsetter)
   m = get_julia_data(lm)
   if name ∈ rolenames(m)
@@ -517,6 +757,12 @@ function removerole(lm::ListModel, idx::Integer)
   emit_roles_changed(lm)
 end
 
+"""
+    function removerole(model::ListModel, name::AbstractString)
+
+Remove one of the [`roles`](@ref) from a [`ListModel`](@ref). See the example for
+[`addrole`](@ref).
+"""
 function removerole(lm::ListModel, name::AbstractString)
   m = get_julia_data(lm)
   idx = findfirst(isequal(name), m.roles)
@@ -528,6 +774,44 @@ function removerole(lm::ListModel, name::AbstractString)
   removerole(lm,idx)
 end
 
+"""
+    function setconstructor(model::ListModel, constructor)
+
+Add a constructor to a list model. The `constructor` will process `append`ed items before
+they are added.
+
+```jldoctest
+julia> using QML
+
+julia> items = ["A", "B"];
+
+julia> array_model = ListModel(items, false);
+
+julia> setconstructor(array_model, uppercase);
+
+julia> mktempdir() do folder
+          path = joinpath(folder, "main.qml")
+          write(path, \"""
+          import QtQuick 2.0
+          import QtQuick.Controls 1.0
+          import QtQuick.Layouts 1.0
+          ApplicationWindow {
+            visible: true
+            Button {
+              text: "Add C"
+              onClicked: array_model.append(["c"])
+            }
+            Timer {
+              running: true
+              onTriggered: Qt.quit()
+            }
+          }
+          \""")
+          load(path; array_model = array_model)
+          exec()
+        end
+```
+"""
 function setconstructor(lm::ListModel, constructor)
   get_julia_data(lm).constructor = constructor
 end
@@ -544,37 +828,6 @@ Base.size(lm::ListModel) = Base.size(get_julia_data(lm).values)
 Base.length(lm::ListModel) = length(get_julia_data(lm).values)
 Base.delete!(lm::ListModel, i) = remove(lm, i-1)
 
-@doc """
-Module for building [Qt5 QML](http://doc.qt.io/qt-5/qtqml-index.html) graphical user interfaces for Julia programs.
-Types starting with `Q` are equivalent of their Qt C++ counterpart, so they have no Julia docstring and we refer to
-the [Qt documentation](http://doc.qt.io/qt-5/qtqml-index.html) for details instead.
-""" QML
-
-@doc "Equivalent to [`QQmlEngine::rootContext`](http://doc.qt.io/qt-5/qqmlengine.html#rootContext)" root_context
-
-@doc "Equivalent to `QLibraryInfo::location(QLibraryInfo::PrefixPath)`" qt_prefix_path
-@doc "Equivalent to `QQuickWindow::contentItem`" content_item
-@doc "Equivalent to `QQuickView::setSource`" set_source
-@doc "Equivalent to `QQuickView::show`" show
-@doc "Equivalent to `QQuickView::engine`" engine
-@doc "Equivalent to `QQuickView::rootObject`" root_object
-
-@doc "Equivalent to `QByteArray::toString`" to_string
-
-@doc """
-Equivalent to `QQmlComponent::setData`. Use this to set the QML code for a QQmlComponent from a Julia string literal.
-""" set_data
-
-@doc """
-Equivalent to `QQmlComponent::create`. This creates a component defined by the QML code set using `set_data`.
-It also makes sure the newly created object is parented to the given context.
-""" create
-
-@doc """
-qmlfunction(name, function)
-
-Register the given function using the given name. Useful for registering functions from a non-exported module or renaming a function upon register (e.g. removing the !)
-
-""" qmlfunction
+include("docs.jl")
 
 end

--- a/src/QML.jl
+++ b/src/QML.jl
@@ -1,14 +1,15 @@
 module QML
 
 export QVariant, QString, QUrl
-export QQmlContext, root_context, load, qt_prefix_path, set_source, engine, QByteArray, to_string, QQmlComponent, set_data, create, QQuickItem, content_item, JuliaObject, QTimer, context_property, emit, JuliaDisplay, JuliaCanvas, init_application, qmlcontext, init_qmlapplicationengine, init_qmlengine, init_qquickview, exec, exec_async, ListModel, addrole, setconstructor, removerole, setrole, roles, QVariantMap
+export QQmlContext, root_context, load, qt_prefix_path, set_source, engine, QByteArray, to_string, QQmlComponent, set_data, create, QQuickItem, content_item, QTimer, context_property, emit, JuliaDisplay, JuliaCanvas, init_application, qmlcontext, init_qmlapplicationengine, init_qmlengine, init_qquickview, exec, exec_async, ListModel, addrole, setconstructor, removerole, setrole, roles, QVariantMap
 export JuliaPropertyMap
 export QStringList, QVariantList
-export QPainter, device, width, height, logicalDpiX, logicalDpiY, QQuickWindow, effectiveDevicePixelRatio, window, JuliaPaintedItem, update
+export QPainter, device, width, height, logicalDpiX, logicalDpiY, QQuickWindow, effectiveDevicePixelRatio, window, JuliaPaintedItem
 export @emit, @qmlfunction, qmlfunction, load, QQmlPropertyMap
 export set_context_property
 
-# TODO: Document GR: device, width, height, JuliaPaintedItem, window, effectiveDevicePixelRatio, logicalDpiX, logicalDpiY
+# TODO: Document: init_application, init_qmlapplicationengine
+# TODO: Document painter: device, effectiveDevicePixelRatio, height, JuliaCanvas, JuliaPaintedItem, logicalDpiX, logicalDpiY, width, window
 
 using jlqml_jll
 
@@ -561,7 +562,7 @@ A constructor (the `eltype`) and setter and getter "roles" based on the `fieldna
 `eltype` will be automatically created if `addroles` is `true`.
 
 If new elements need to be constructed from QML, a constructor can also be provided, using
-the [`setconstructor`](@ref) method.
+the [`setconstructor`](@ref) method. QML can pass a list of arguments to constructors.
 
 In Qt, each of the elements of a model has a series of roles, available as properties in the
 delegate that is used to display each item. The roles can be added using the
@@ -599,15 +600,15 @@ julia> mktempdir() do folder
                   }
                   Button {
                     text: "Duplicate"
-                    onClicked: fruits.append({"name": name, "cost": cost})
+                    onClicked: fruits.append([name, cost])
                   }
                   Timer {
                     running: true
                     onTriggered: Qt.quit()
                   }
                 }
+              }
             }
-          }
           \""")
           load(path; fruits = fruits)
           exec()
@@ -778,7 +779,8 @@ end
     function setconstructor(model::ListModel, constructor)
 
 Add a constructor to a [`ListModel`](@ref). The `constructor` will process `append`ed items
-before they are added.
+before they are added. Note that you can simply pass a list of arguments tofrom QML,
+and they will be interpret in Julia as positional arguments.
 
 ```jldoctest
 julia> using QML

--- a/src/QML.jl
+++ b/src/QML.jl
@@ -1,7 +1,7 @@
 module QML
 
 export QVariant, QString, QUrl
-export QQmlContext, root_context, load, qt_prefix_path, set_source, engine, QByteArray, to_string, QQmlComponent, set_data, create, QQuickItem, content_item, QTimer, context_property, emit, JuliaDisplay, qmlcontext, init_qmlengine, init_qquickview, exec, exec_async, ListModel, addrole, setconstructor, removerole, setrole, roles, QVariantMap
+export QQmlContext, root_context, load, qt_prefix_path, set_source, engine, QByteArray, to_string, QQmlComponent, set_data, create, QQuickItem, content_item, QTimer, context_property, emit, JuliaDisplay, JuliaCanvas, qmlcontext, init_qmlengine, init_qquickview, exec, exec_async, ListModel, addrole, setconstructor, removerole, setrole, roles, QVariantMap
 export JuliaPropertyMap
 export QStringList, QVariantList
 export QPainter, device, width, height, logicalDpiX, logicalDpiY, QQuickWindow, effectiveDevicePixelRatio, window, JuliaPaintedItem

--- a/src/docs.jl
+++ b/src/docs.jl
@@ -85,7 +85,8 @@ engine
     function exec()
 
 Fill out a window. Use with a [`QQmlApplicationEngine`](@ref), [`QQuickView`](@ref), or
-[`QQmlComponent`](@ref).
+[`QQmlComponent`](@ref). Note that after calling `exec`, you will need to reregister
+functions, e.g. with [`@qmlfunction`], if you want to `exec` again.
 """
 exec
 
@@ -179,7 +180,7 @@ QML
 """
     function qmlcontext()
 
-Create an empty context for QML. Required for [`set_data`](@ref).
+Create an empty context for QML. Required for [`create`](@ref).
 """
 qmlcontext
 

--- a/src/docs.jl
+++ b/src/docs.jl
@@ -1,0 +1,473 @@
+"""
+    function content_item(quick_view::QQuickView)
+
+Get the content item of a quick view. Equivalent to `QQuickWindow::contentItem`.
+
+```jldoctest
+julia> using QML
+
+julia> using CxxWrap.CxxWrapCore: CxxPtr
+
+julia> quick_view = mktempdir() do folder
+          path = joinpath(folder, "main.qml")
+          write(path, \"""
+          import QtQuick 2.0
+          import QtQuick.Controls 1.0
+          Rectangle {
+            Timer {
+              running: true
+              onTriggered: Qt.quit()
+            }
+          }
+          \""")
+          quick_view = init_qquickview()
+          set_source(quick_view, QUrl(path))
+          @assert content_item(quick_view) isa CxxPtr{QQuickItem}
+          exec()
+        end
+```
+"""
+content_item
+
+"""
+    function context_property(context::QQmlContext, item::AbstractString)
+
+Get a context property. See the example for [`root_context`](@ref).
+"""
+context_property
+
+"""
+    function create(component::QQmlComponent, context::QQmlContext)
+
+Equivalent to `QQmlComponent::create`. This creates a component defined by the QML code set
+using `set_data`. It also makes sure the newly created object is parented to the given
+`context`. See the example for [`set_data`](@ref).
+"""
+create
+
+"""
+    function engine(quick_view::QQuickView)
+
+Equivalent to `QQuickView::engine`. If you would like to modify the context of a
+[`QQuickView`](@ref), use `engine` to get an engine from the window, and then
+[`root_context`](@ref) to get the context from the engine.
+
+```jldoctest
+julia> using QML
+
+julia> mktempdir() do folder
+          path = joinpath(folder, "main.qml")
+          write(path, \"""
+          import QtQuick 2.0
+          import QtQuick.Controls 1.0
+          Rectangle {
+            Text {
+              text: greeting
+            }
+            Timer {
+              running: true
+              onTriggered: Qt.quit()
+            }
+          }
+          \""")
+          quick_view = init_qquickview()
+          context = root_context(engine(quick_view))
+          set_context_property(context, "greeting", "Hello, World!")
+          set_source(quick_view, QUrl(path))
+          QML.show(quick_view)
+          exec()
+        end
+```
+"""
+engine
+
+"""
+    function exec()
+
+Fill out a window. Use with a [`QQmlApplicationEngine`](@ref), [`QQuickView`](@ref), or
+[`QQmlComponent`](@ref).
+"""
+exec
+
+"""
+    function exec_async()
+
+Similar to [`exec`](@ref), but will not block the main process. This method keeps the REPL
+active and polls the QML interface periodically for events, using a timer in the Julia event
+loop.
+"""
+exec_async
+
+"""
+    function init_qmlengine()
+
+Create a QML engine. You can modify the context of an engine using [`root_context`](@ref).
+You can use an engine to create `QQmlComponent`s. See the example for [`set_data`](@ref).
+Note that you can also get the engine for a `QQuickView` using [`engine`](@ref).
+"""
+init_qmlengine
+
+"""
+    function init_qquickview()
+
+Create a [`QQuickView`](@ref).
+"""
+init_qquickview
+
+"""
+    struct JuliaDisplay
+
+You can use `display` to send images to a JuliaDisplay. There is a corresponding QML block
+called JuliaDisplay. Of course the display can also be added using `pushdisplay!`, but
+passing by value can be more convenient when defining multiple displays in QML. See below
+for syntax.
+
+```jldoctest
+julia> using QML
+
+julia> using Plots: plot
+
+julia> function simple_plot(julia_display::JuliaDisplay)
+          x = 0:1:10
+          display(julia_display, plot(x, x, show = false, size = (500, 500)))
+          nothing
+        end;
+
+julia> @qmlfunction simple_plot
+
+julia> mktempdir() do folder
+          path = joinpath(folder, "main.qml")
+          write(path, \"""
+          import QtQuick 2.0
+          import QtQuick.Controls 1.0
+          import QtQuick.Layouts 1.0
+          import org.julialang 1.0
+          ApplicationWindow {
+            visible: true
+            Column {
+              Button {
+                text: "Plot"
+                onClicked: Julia.simple_plot(julia_display)
+              }
+              JuliaDisplay {
+                id: julia_display
+                width: 500
+                height: 500
+              }
+              Timer {
+                running: true
+                onTriggered: Qt.quit()
+              }
+            }
+          }
+          \""")
+          load(path)
+          exec()
+        end
+
+```
+"""
+JuliaDisplay
+
+"""
+Module for building [Qt5 QML](http://doc.qt.io/qt-5/qtqml-index.html) graphical user interfaces for Julia programs.
+Types starting with `Q` are equivalent of their Qt C++ counterpart, so, unless otherwise noted, they have no Julia docstring and we refer to
+the [Qt documentation](http://doc.qt.io/qt-5/qtqml-index.html) for details instead.
+"""
+QML
+
+"""
+    function qmlcontext()
+
+Create an empty context for QML. Required for [`set_data`](@ref).
+"""
+qmlcontext
+
+"""
+    function qmlfunction(function_name::String, a_function)
+
+Register `a_function` using `function_name`. If you want to register a function under
+it's own name, you can use [`@qmlfunction`](@ref). Note, however, that you can't use the
+macro for registering functions from a non-exported module or registering functions wtih
+`!` in the name.
+"""
+qmlfunction
+
+"""
+    function QByteArray(a_string::String)
+
+Use to pass text to [`set_data`](@ref).
+"""
+QByteArray
+
+"""
+    struct QQmlApplicationEngine
+
+One of 3 ways to interact with QML (the others being [`QQuickView`](@ref) and
+[`QQmlComponent`](@ref). You can load a QML file to create an engine with [`load`](@ref).
+Use [`exec`](@ref) to execute a file after it's been loaded.
+
+The lifetime of the `QQmlApplicationEngine` is managed from C++ and it gets cleaned up when
+the application  quits. This means it is not necessary to keep a reference to the engine to
+prevent it from being garbage collected prematurely.
+
+```jldoctest
+julia> using QML
+
+julia> mktempdir() do folder
+          path = joinpath(folder, "main.qml")
+          write(path, \"""
+          import QtQuick 2.0
+          import QtQuick.Controls 1.0
+          ApplicationWindow {
+            visible: true
+            Text {
+              text: greeting
+            }
+            Timer {
+              running: true
+              onTriggered: Qt.quit()
+            }
+          }
+          \""")
+          load(path; greeting = "Hello, World!")
+          exec()
+        end
+```
+"""
+QQmlApplicationEngine
+
+"""
+    struct QQmlComponent
+
+One of 3 ways to interact with QML (the others being [`QQmlApplicationEngine`](@ref) and
+[`QQuickView`](@ref). Make from an engine from e.g.[`init_qmlengine`](@ref).
+Use [`set_data`](@ref) to set the QML code, [`create`](@ref) to create the window, and
+[`exec`](@ref) to fill the window.
+
+```jldoctest
+julia> using QML
+
+julia> component = QQmlComponent(init_qmlengine());
+
+julia> set_data(component, QByteArray(\"""
+          import QtQuick 2.0
+          import QtQuick.Controls 1.0
+          ApplicationWindow {
+            visible: true
+            Rectangle {
+              Text {
+                text: "Hello, World!"
+              }
+              Timer {
+                running: true
+                onTriggered: Qt.quit()
+              }
+            }
+          }
+        \"""), QUrl())
+
+julia> create(component, qmlcontext())
+
+julia> exec()
+```
+"""
+QQmlComponent
+
+"""
+    function qt_prefix_path()
+
+Equivalent to `QLibraryInfo::location(QLibraryInfo::PrefixPath)`. Useful to check whether
+the intended Qt version is being used.
+
+```jldoctest
+julia> using QML
+
+julia> isdir(qt_prefix_path())
+true
+```
+"""
+qt_prefix_path
+
+"""
+    struct QQuickView
+
+One of 3 ways to interact with QML (the others being [`QQmlApplicationEngine`](@ref) and
+[`QQmlComponent`](@ref). `QQuickView` creates a window, so it's not necessary to wrap the
+QML in ApplicationWindow. Use [`init_qquickview`](@ref) to create a quick view,
+[`set_source`](@ref) to set the source for the quick view, [`QML.show`](@ref) to view, and
+[`exec`](@ref) to execute.
+
+```jldoctest
+julia> using QML
+
+julia> mktempdir() do folder
+          path = joinpath(folder, "main.qml")
+          write(path, \"""
+          import QtQuick 2.0
+          import QtQuick.Controls 1.0
+          Rectangle {
+            Text {
+              text: "Hello, World!"
+            }
+            Timer {
+              running: true
+              onTriggered: Qt.quit()
+            }
+          }
+          \""")
+          quick_view = init_qquickview()
+          set_source(quick_view, QUrl(path))
+          QML.show(quick_view)
+          exec()
+        end
+```
+"""
+QQuickView
+
+"""
+    struct QTimer
+
+You can use `QTimer` to simulate running Julia in the background. Note that QML provides the
+infrastructure to connect to the `QTimer` signal through the `Connections` item.
+
+```jldoctest
+julia> using QML
+
+julia> counter = Ref(0);
+
+julia> increment() = counter[] += 1;
+
+julia> @qmlfunction increment
+
+julia> mktempdir() do folder
+          path = joinpath(folder, "main.qml")
+          write(path, \"""
+          import QtQuick 2.0
+          import QtQuick.Controls 1.0
+          import org.julialang 1.0
+          ApplicationWindow {
+              visible: true
+              Connections {
+                target: timer
+                function onTimeout() {
+                  Julia.increment()
+                }
+              }
+              Button {
+                  text: "Start counting"
+                  onClicked: timer.start()
+              }
+              Timer { // unrelated, this is a timer to stop and continue testing
+                running: true
+                onTriggered: Qt.quit()
+              }
+          }
+          \""")
+          load(path, timer=QTimer())
+          exec()
+        end
+```
+"""
+QTimer
+
+"""
+    struct QUrl([filename::String])
+
+Used to pass filenames to [`set_source`](@ref). Pass an empty url (no arguments) to
+[`set_data`](@ref).
+"""
+QUrl
+
+"""
+    root_context(an_engine::QQmlEngine)
+
+Get the context of `an_engine`. Equivalent to
+[`QQmlEngine::rootContext`](http://doc.qt.io/qt-5/qqmlengine.html#rootContext). Use
+[`set_context_property`](@ref) to modify the context. Use [`context_property`](@ref) to
+get a particular property. Use to get the context of an engine created with
+[`init_qmlengine`](@ref) before using [`set_data`](@ref) or from [`engine`](@ref).
+
+```jldoctest
+julia> using QML
+
+julia> an_engine = init_qmlengine();
+
+julia> context = root_context(an_engine);
+
+julia> set_context_property(context, "greeting", "Hello, World!");
+
+julia> context_property(context, "greeting")
+QVariant of type QML.QString with value Hello, World!
+
+julia> component = QQmlComponent(an_engine);
+
+julia> set_data(component, QByteArray(\"""
+          import QtQuick 2.0
+          import QtQuick.Controls 1.0
+          ApplicationWindow {
+            visible: true
+            Rectangle {
+              Text {
+                text: greeting
+              }
+              Timer {
+                running: true
+                onTriggered: Qt.quit()
+              }
+            }
+          }
+        \"""), QUrl())
+
+julia> create(component, qmlcontext())
+
+julia> exec()
+```
+"""
+root_context
+
+"""
+    set_context_property(context::QQmlContext, name::String, value::Any)
+
+Set properties. See [`root_context`](@ref) for an example.
+"""
+set_context_property
+
+"""
+    function set_data(component::QQmlComponent, data::QByteArray, file::QUrl)
+
+Equivalent to `QQmlComponent::setData`. Use this to set the QML code for a
+[`QQmlComponent`](@ref) from a Julia string literal wrapped in a [`QByteArray`](@ref). Also
+requires an empty [`QUrl`](@ref). See [`QQmlComponent`](@ref) for an example.
+"""
+set_data
+
+"""
+    function set_source(window::QQuickView, file::QUrl)
+
+Equivalent to `QQuickView::setSource`. See the example for [`init_qquickview`](@ref). The
+file path should be a path wrapped with [`QUrl`](@ref).
+"""
+set_source
+
+@doc """
+     function QML.show()
+
+Equivalent to `QQuickView::show`. See example for [`QQuickView`](@ref).
+"""
+show
+
+"""
+    function to_string(data::QByteArray)
+
+Equivalent to `QByteArray::toString`. Use to convert a [`QByteArray`](@ref) back to a
+string.
+
+```jldoctest
+julia> using QML
+
+julia> to_string(QByteArray("Hello, World!"))
+"Hello, World!"
+```
+"""
+to_string

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,10 @@
 using Test
 
+import QML
+using Documenter: doctest
+
+doctest(QML)
+
 excluded = ["runtests.jl", "qml", "include"]
 
 # OpenGL on Linux travis is excessively old, causing a crash when attempting display of a window


### PR DESCRIPTION
So... this is a WIP but I'm not sure I'll be able to make much more progress. I've made the following changes:

- Added a github actions infrastructure to build the docs. Also has a lot of other bells and whistles
- Moved lone docstrings to a separate file
- Added a whole bunch of doc tests.
- Unexported a couple of unused and undocumented functions...mostly because I couldn't figure out what they were for.
- Rewrote `@expand_dots`, because it didn't seem to work on 1.4

I haven't documented any of the GR or JuliaCanvas stuff, in part because it's marked as experimental, but mostly because I can't figure it out. I think most of the docs are correct, but I'm sure there's stuff I've gleaned wrong. I'm still confused by why it's necessary to pass empty `QUrl` and `qmlcontext`s.