### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ See https://barche.github.io/QML.jl/dev
 To run the included examples, execute:
 
 ```julia
-include(joinpath(Pkg.dir("QML"), "example", "runexamples.jl"))
+include(joinpath(dirname(pathof(QML)), "..", "example", "runexamples.jl"))
 ```
 
 The examples require some additional packages to be described by the manifest and project files in the examples directory, so from the examples directory you should


### PR DESCRIPTION
replace depreciated Pkg.dir with pathof

```julia
julia> include(joinpath(Pkg.dir("QML"), "example", "runexamples.jl"))
┌ Warning: `Pkg.dir(pkgname, paths...)` is deprecated; instead, do `import QML; joinpath(dirname(pathof(QML)), "..", paths...)`.
```